### PR TITLE
Add Unit Tests

### DIFF
--- a/examples/putsecret/main.go
+++ b/examples/putsecret/main.go
@@ -19,7 +19,7 @@ func main() {
 	flag.Parse()
 
 	if len(flag.Args()) < 3 {
-		fmt.Printf("usage: %s owner repo secret-id secret-value", os.Args[0])
+		fmt.Printf("usage: %s [-dry] owner repo secret-id secret-value", os.Args[0])
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/jefflinse/githubsecret
 
 go 1.15
 
-require golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c
+require (
+	github.com/stretchr/testify v1.6.1
+	golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c h1:9HhBz5L/UjnK9XLtiZhYAdue5BVKep3PMmS2LuPDt8k=
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
@@ -7,3 +14,6 @@ golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/nacl.go
+++ b/nacl.go
@@ -3,6 +3,7 @@ package githubsecret
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"fmt"
 
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/nacl/box"
@@ -13,6 +14,9 @@ const (
 	nonceSize = 24
 )
 
+// Test indirection
+var generateKey = box.GenerateKey
+
 // Encrypt encrypts a secret using the provided recipient public key.
 func Encrypt(recipientPublicKey string, content string) (string, error) {
 	// decode the provided public key from base64
@@ -20,12 +24,14 @@ func Encrypt(recipientPublicKey string, content string) (string, error) {
 	b, err := base64.StdEncoding.DecodeString(recipientPublicKey)
 	if err != nil {
 		return "", err
+	} else if size := len(b); size != keySize {
+		return "", fmt.Errorf("recipient public key has invalid length (%d bytes)", size)
 	}
 
 	copy(recipientKey[:], b)
 
 	// create an ephemeral key pair
-	pubKey, privKey, err := box.GenerateKey(rand.Reader)
+	pubKey, privKey, err := generateKey(rand.Reader)
 	if err != nil {
 		return "", err
 	}

--- a/nacl_test.go
+++ b/nacl_test.go
@@ -1,0 +1,100 @@
+package githubsecret
+
+import (
+	"encoding/base64"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	mockValidSecretValue          = "a valid secret value"
+	mockValidPublicKey            = "hel9i9lSE4Cu103BBICvKhmLi8LLnVO7BDdqANPOlEw="
+	mockInvalidPublicKeyTooShort  = "z8Viu/+IGVACPAltd3UpMCBWV+yxUZkDXkQcQwK/"
+	mockInvalidPublicKeyTooLong   = "mSu6F6vPOCU7inMJ1CNsXPCc1f/oN6hgfSWjuxvoxQTeeA=="
+	mockInvalidPublicKeyNotBase64 = "this is certainly not base64!"
+
+	mockGeneratedPublicKey  = "Gj5IXxUxMQ5tEVN7a83nwiBC/e5ckiWTkPRH3G3FNBw="
+	mockGeneratedPrivateKey = "uXts8kET12LelZEmqhnscs/0Qj4CpC3V3yWhFfo9czk="
+)
+
+func TestEncrypt(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		pk             string
+		secret         string
+		expectedOutput string
+		expectedError  error
+	}{
+		{
+			name:           "can encode an empty secret with a valid recipient pk",
+			pk:             mockValidPublicKey,
+			secret:         "",
+			expectedOutput: "Gj5IXxUxMQ5tEVN7a83nwiBC/e5ckiWTkPRH3G3FNBxAvNLVFmltuTJxCdc5joBu",
+			expectedError:  nil,
+		},
+		{
+			name:           "can encode a non-empty secret with a valid recipient pk",
+			pk:             mockValidPublicKey,
+			secret:         mockValidSecretValue,
+			expectedOutput: "Gj5IXxUxMQ5tEVN7a83nwiBC/e5ckiWTkPRH3G3FNBzNnh9ZMlNTPy2fTY6WSlvJ3CBqQVYj2jQwqwMSTcShAiaQCIk=",
+			expectedError:  nil,
+		},
+		{
+			name:           "fails when the recipient pk is empty",
+			pk:             "",
+			secret:         mockValidSecretValue,
+			expectedOutput: "",
+			expectedError:  errors.New("recipient public key has invalid length (0 bytes)"),
+		},
+		{
+			name:           "fails when the recipient pk is too short",
+			pk:             mockInvalidPublicKeyTooShort,
+			secret:         mockValidSecretValue,
+			expectedOutput: "",
+			expectedError:  errors.New("recipient public key has invalid length (30 bytes)"),
+		},
+		{
+			name:           "fails when the recipient pk is too long",
+			pk:             mockInvalidPublicKeyTooLong,
+			secret:         mockValidSecretValue,
+			expectedOutput: "",
+			expectedError:  errors.New("recipient public key has invalid length (34 bytes)"),
+		},
+		{
+			name:           "fails when the recipient pk is not valid base64",
+			pk:             mockInvalidPublicKeyNotBase64,
+			secret:         mockValidSecretValue,
+			expectedOutput: "",
+			expectedError:  errors.New("illegal base64 data at input byte 4"),
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			origGenerateKey := generateKey
+			defer func() { generateKey = origGenerateKey }()
+			generateKey = mockGenerateKey
+
+			output, err := Encrypt(test.pk, test.secret)
+			if test.expectedError != nil {
+				assert.EqualError(t, err, test.expectedError.Error())
+				assert.Empty(t, output)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedOutput, output)
+				assert.True(t, strings.HasPrefix(output, mockGeneratedPublicKey[:len(mockGeneratedPublicKey)-2]))
+			}
+		})
+	}
+}
+
+// Returns a predefined keypair for mocking out randomness in nonce generation.
+func mockGenerateKey(r io.Reader) (*[32]byte, *[32]byte, error) {
+	pub := new([keySize]byte)
+	base64.StdEncoding.Decode(pub[:], []byte(mockGeneratedPublicKey))
+	priv := new([keySize]byte)
+	base64.StdEncoding.Decode(priv[:], []byte(mockGeneratedPrivateKey))
+	return pub, priv, nil
+}

--- a/nacl_test.go
+++ b/nacl_test.go
@@ -26,6 +26,7 @@ func TestEncrypt(t *testing.T) {
 		name           string
 		pk             string
 		secret         string
+		generateKeyFn  func(r io.Reader) (*[32]byte, *[32]byte, error)
 		expectedOutput string
 		expectedError  error
 	}{
@@ -33,6 +34,7 @@ func TestEncrypt(t *testing.T) {
 			name:           "can encode an empty secret with a valid recipient pk",
 			pk:             mockValidPublicKey,
 			secret:         "",
+			generateKeyFn:  mockGenerateKey,
 			expectedOutput: "Gj5IXxUxMQ5tEVN7a83nwiBC/e5ckiWTkPRH3G3FNBxAvNLVFmltuTJxCdc5joBu",
 			expectedError:  nil,
 		},
@@ -40,6 +42,7 @@ func TestEncrypt(t *testing.T) {
 			name:           "can encode a non-empty secret with a valid recipient pk",
 			pk:             mockValidPublicKey,
 			secret:         mockValidSecretValue,
+			generateKeyFn:  mockGenerateKey,
 			expectedOutput: "Gj5IXxUxMQ5tEVN7a83nwiBC/e5ckiWTkPRH3G3FNBzNnh9ZMlNTPy2fTY6WSlvJ3CBqQVYj2jQwqwMSTcShAiaQCIk=",
 			expectedError:  nil,
 		},
@@ -47,6 +50,7 @@ func TestEncrypt(t *testing.T) {
 			name:           "fails when the recipient pk is empty",
 			pk:             "",
 			secret:         mockValidSecretValue,
+			generateKeyFn:  mockGenerateKey,
 			expectedOutput: "",
 			expectedError:  errors.New("recipient public key has invalid length (0 bytes)"),
 		},
@@ -54,6 +58,7 @@ func TestEncrypt(t *testing.T) {
 			name:           "fails when the recipient pk is too short",
 			pk:             mockInvalidPublicKeyTooShort,
 			secret:         mockValidSecretValue,
+			generateKeyFn:  mockGenerateKey,
 			expectedOutput: "",
 			expectedError:  errors.New("recipient public key has invalid length (30 bytes)"),
 		},
@@ -61,6 +66,7 @@ func TestEncrypt(t *testing.T) {
 			name:           "fails when the recipient pk is too long",
 			pk:             mockInvalidPublicKeyTooLong,
 			secret:         mockValidSecretValue,
+			generateKeyFn:  mockGenerateKey,
 			expectedOutput: "",
 			expectedError:  errors.New("recipient public key has invalid length (34 bytes)"),
 		},
@@ -68,14 +74,25 @@ func TestEncrypt(t *testing.T) {
 			name:           "fails when the recipient pk is not valid base64",
 			pk:             mockInvalidPublicKeyNotBase64,
 			secret:         mockValidSecretValue,
+			generateKeyFn:  mockGenerateKey,
 			expectedOutput: "",
 			expectedError:  errors.New("illegal base64 data at input byte 4"),
+		},
+		{
+			name:   "fails when the ephemeral key pair cannot be generated",
+			pk:     mockValidPublicKey,
+			secret: mockValidSecretValue,
+			generateKeyFn: func(_ io.Reader) (*[32]byte, *[32]byte, error) {
+				return nil, nil, assert.AnError
+			},
+			expectedOutput: "",
+			expectedError:  assert.AnError,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			origGenerateKey := generateKey
 			defer func() { generateKey = origGenerateKey }()
-			generateKey = mockGenerateKey
+			generateKey = test.generateKeyFn
 
 			output, err := Encrypt(test.pk, test.secret)
 			if test.expectedError != nil {


### PR DESCRIPTION
### Summary

Add unit tests

### Changes

- Adds unit tests for `Encrypt()`. Test coverage is now 85.7%.
- Adds the `-dry` flag to the usage text for the `putsecret` example app